### PR TITLE
Add TLS ClientHello inspection API

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -292,6 +292,14 @@ internal static partial class Interop
                     Interop.Ssl.SslCtxSetAlpnSelectCb(sslCtx, &AlpnServerSelectCallback, IntPtr.Zero);
                 }
 
+                if (sslAuthenticationOptions.IsServer && sslAuthenticationOptions.EnableClientHelloCallback)
+                {
+                    // Pause the handshake at ClientHello and capture the raw bytes so
+                    // managed callers can inspect them (e.g. SNI/ALPN routing) before
+                    // any certificate or server-option decision is made.
+                    Interop.Ssl.SslCtxSetClientHelloCallback(sslCtx, 1);
+                }
+
                 if (sslAuthenticationOptions.CertificateContext != null && sslAuthenticationOptions.IsServer)
                 {
                     SetSslCertificate(sslCtx, sslAuthenticationOptions.CertificateContext.CertificateHandle, sslAuthenticationOptions.CertificateContext.KeyHandle);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -773,6 +773,16 @@ internal static partial class Interop
                     return SecurityStatusPalErrorCode.CertValidationNeeded;
                 }
 
+                if (errorCode == Ssl.SslErrorCode.SSL_ERROR_WANT_CLIENT_HELLO_CB)
+                {
+                    // The ClientHello callback paused the handshake so managed callers
+                    // can inspect the raw ClientHello bytes (already captured into the
+                    // SSL object's ex_data). The handshake resumes on the next
+                    // DoSslHandshake call. No output was produced yet (ServerHello is
+                    // generated on resume), so there is nothing to drain here.
+                    return SecurityStatusPalErrorCode.ClientHelloNeeded;
+                }
+
                 if (errorCode == Ssl.SslErrorCode.SSL_ERROR_SSL && context.CertificateValidationException is Exception ex)
                 {
                     // Clear the OpenSSL error queue since we are using our own

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -259,6 +259,12 @@ internal static partial class Interop
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetClientCertCallback")]
         internal static unsafe partial void SslSetClientCertCallback(SafeSslHandle ssl, int set);
 
+        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetClientHelloCallback")]
+        internal static partial void SslCtxSetClientHelloCallback(SafeSslContextHandle ctx, int enable);
+
+        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetClientHelloData")]
+        internal static unsafe partial int SslGetClientHelloData(SafeSslHandle ssl, out byte* data, out int length);
+
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetPostHandshakeAuth")]
         internal static partial void SslSetPostHandshakeAuth(SafeSslHandle ssl, int value);
 
@@ -429,6 +435,7 @@ internal static partial class Interop
             SSL_ERROR_WANT_X509_LOOKUP = 4,
             SSL_ERROR_SYSCALL = 5,
             SSL_ERROR_ZERO_RETURN = 6,
+            SSL_ERROR_WANT_CLIENT_HELLO_CB = 11,
             SSL_ERROR_WANT_RETRY_VERIFY = 12,
 
             // NOTE: this SslErrorCode value doesn't exist in OpenSSL, but

--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -696,11 +696,13 @@ namespace System.Net.Security
         WantCredentials = 4,
         NeedsCertificateValidation = 5,
         NeedsServerOptions = 6,
+        NeedsClientHello = 7,
     }
     public sealed partial class TlsContext : System.IDisposable
     {
         internal TlsContext() { }
         public bool IsServer { get { throw null; } }
+        public bool EnableClientHelloInspection { get { throw null; } set { } }
         public static System.Net.Security.TlsContext Create(System.Net.Security.SslServerAuthenticationOptions? options) { throw null; }
         public static System.Net.Security.TlsContext Create(System.Net.Security.SslClientAuthenticationOptions options) { throw null; }
         public void Dispose() { }
@@ -734,6 +736,7 @@ namespace System.Net.Security
         public void SetServerOptions(System.Net.Security.SslServerAuthenticationOptions options) { }
         public void SetClientCertificateContext(System.Net.Security.SslStreamCertificateContext context) { }
         public System.Collections.Generic.IReadOnlyList<string>? GetAcceptableIssuers() { throw null; }
+        public System.ReadOnlySpan<byte> GetClientHelloBytes() { throw null; }
         public System.Security.Cryptography.X509Certificates.X509Certificate2? LocalCertificate { get { throw null; } }
         public System.Security.Authentication.ExtendedProtection.ChannelBinding? GetChannelBinding(System.Security.Authentication.ExtendedProtection.ChannelBindingKind kind) { throw null; }
         public System.Net.Security.TlsOperationStatus RequestClientCertificate(System.Span<byte> ciphertext, out int bytesWritten) { throw null; }

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -78,6 +78,8 @@
              Condition="'$(TargetPlatformIdentifier)' == 'linux' or '$(TargetPlatformIdentifier)' == 'freebsd' or '$(TargetPlatformIdentifier)' == 'windows' or '$(UseAppleCrypto)' == 'true'" />
     <Compile Include="System\Net\Security\TlsSession.OpenSsl.cs"
              Condition="'$(TargetPlatformIdentifier)' == 'linux' or '$(TargetPlatformIdentifier)' == 'freebsd'" />
+    <Compile Include="System\Net\Security\TlsSession.Windows.cs"
+             Condition="'$(TargetPlatformIdentifier)' == 'windows'" />
     <Compile Include="System\Net\Security\TlsSession.Stub.cs"
              Condition="'$(TargetPlatformIdentifier)' != 'linux' and '$(TargetPlatformIdentifier)' != 'freebsd' and '$(TargetPlatformIdentifier)' != 'windows' and '$(UseAppleCrypto)' != 'true'" />
     <Compile Include="System\Net\Security\SslStreamCertificateContext.cs" />

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -224,6 +224,7 @@ namespace System.Net.Security
                 AllowRsaPssPadding = AllowRsaPssPadding,
                 AllowRsaPkcs1Padding = AllowRsaPkcs1Padding,
                 ForceSyncPal = ForceSyncPal,
+                EnableClientHelloCallback = EnableClientHelloCallback,
             };
             return copy;
         }
@@ -256,6 +257,10 @@ namespace System.Net.Security
         // Set by callers (e.g. TlsSession) whose state machine is intrinsically synchronous
         // and cannot use the async Network Framework PAL path on macOS.
         internal bool ForceSyncPal { get; set; }
+
+        // Server-side only. When set, the OpenSSL handshake pauses once at ClientHello and
+        // the raw ClientHello bytes are captured for inspection by TlsSession callers.
+        internal bool EnableClientHelloCallback { get; set; }
 
 #if TARGET_ANDROID
         internal SslStream.JavaProxy? SslStreamProxy { get; set; }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsContext.cs
@@ -79,6 +79,24 @@ namespace System.Net.Security
         public bool IsServer => _options.IsServer;
 
         /// <summary>
+        /// Server-side only. When set to <see langword="true"/> before the first session
+        /// handshake, the underlying OpenSSL handshake pauses once at ClientHello and the
+        /// raw ClientHello bytes are captured. Sessions then report
+        /// <see cref="TlsOperationStatus.NeedsClientHello"/>, and the bytes can be read via
+        /// <see cref="TlsSession.GetClientHelloBytes"/> before the handshake is resumed.
+        /// </summary>
+        /// <remarks>
+        /// This surfaces the raw handshake message (HandshakeType + length prefix + body),
+        /// without the outer 5-byte TLS record header. It is intended for low-level callers that parse the ClientHello themselves.
+        /// No-op on platforms without the OpenSSL ClientHello callback.
+        /// </remarks>
+        public bool EnableClientHelloInspection
+        {
+            get => _options.EnableClientHelloCallback;
+            set => _options.EnableClientHelloCallback = value;
+        }
+
+        /// <summary>
         /// Creates a server-side TLS context.
         /// </summary>
         /// <param name="options">

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsOperationStatus.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsOperationStatus.cs
@@ -57,5 +57,14 @@ namespace System.Net.Security
         /// <see cref="TlsSession.ProcessHandshake"/> again with the same input.
         /// </summary>
         NeedsServerOptions = 6,
+
+        /// <summary>
+        /// Server-side only. The handshake paused at ClientHello because raw ClientHello
+        /// inspection was enabled on the <see cref="TlsContext"/>. Retrieve the raw bytes
+        /// via <see cref="TlsSession.GetClientHelloBytes"/>, then call
+        /// <see cref="TlsSession.Handshake"/> (fd mode) or
+        /// <see cref="TlsSession.ProcessHandshake"/> again to resume the handshake.
+        /// </summary>
+        NeedsClientHello = 7,
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.OpenSsl.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.OpenSsl.cs
@@ -103,12 +103,34 @@ namespace System.Net.Security
             return handle;
         }
 
+        partial void TryGetClientHelloBytes(ref ReadOnlySpan<byte> result)
+        {
+            // _securityContext is the SafeSslHandle in both fd and BIO modes on Unix
+            // (SafeSslHandle : SafeDeleteSslContext). The captured buffer is owned by the
+            // SSL object and freed on SSL_free, so the span stays valid until this session
+            // (which roots the handle) is disposed.
+            if (_securityContext is not SafeSslHandle ssl || ssl.IsInvalid)
+            {
+                return;
+            }
+
+            unsafe
+            {
+                if (Interop.Ssl.SslGetClientHelloData(ssl, out byte* data, out int length) == 1
+                    && data != null && length > 0)
+                {
+                    result = new ReadOnlySpan<byte>(data, length);
+                }
+            }
+        }
+
         private static TlsOperationStatus MapSslError(Interop.Ssl.SslErrorCode error, string op)
         {
             return error switch
             {
                 Interop.Ssl.SslErrorCode.SSL_ERROR_WANT_READ => TlsOperationStatus.WantRead,
                 Interop.Ssl.SslErrorCode.SSL_ERROR_WANT_WRITE => TlsOperationStatus.WantWrite,
+                Interop.Ssl.SslErrorCode.SSL_ERROR_WANT_CLIENT_HELLO_CB => TlsOperationStatus.NeedsClientHello,
                 Interop.Ssl.SslErrorCode.SSL_ERROR_ZERO_RETURN => TlsOperationStatus.Closed,
                 _ => throw new AuthenticationException($"OpenSSL {op} failed: {error}"),
             };

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.Stub.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.Stub.cs
@@ -83,6 +83,9 @@ namespace System.Net.Security
         public IReadOnlyList<string>? GetAcceptableIssuers() =>
             throw new PlatformNotSupportedException(SR.SystemNetSecurity_PlatformNotSupported);
 
+        public ReadOnlySpan<byte> GetClientHelloBytes() =>
+            throw new PlatformNotSupportedException(SR.SystemNetSecurity_PlatformNotSupported);
+
         public X509Certificate2? LocalCertificate =>
             throw new PlatformNotSupportedException(SR.SystemNetSecurity_PlatformNotSupported);
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.Windows.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.Security
+{
+    public sealed partial class TlsSession
+    {
+        // Windows/SChannel raw ClientHello inspection.
+        //
+        // Unlike OpenSSL (where SSL_CTX_set_client_hello_cb captures the message natively inside
+        // SSL_do_handshake), SChannel exposes no ClientHello callback. But in the BIO/ProcessHandshake
+        // model the caller hands the ClientHello bytes *into* the session, so the raw message is simply
+        // the first inbound TLS record. We capture it in managed code before SChannel's first
+        // AcceptSecurityContext call, surface NeedsClientHello once, and let the caller re-feed the same
+        // (unconsumed) bytes on resume. The bytes match the OpenSSL shape exactly: the TLS handshake
+        // message (HandshakeType + 3-byte length + body), with no outer 5-byte record header.
+
+        private byte[]? _capturedClientHello;
+        private bool _clientHelloInspected;
+
+        partial void TryCaptureClientHelloForInspection(ReadOnlySpan<byte> input, ref TlsOperationStatus? suspend)
+        {
+            if (_clientHelloInspected || !_options.EnableClientHelloCallback)
+            {
+                return;
+            }
+
+            // The frame guard in ProcessHandshake has already ensured the full first record is present
+            // before the server branch runs, so header.Length bytes are available here.
+            TlsFrameHeader header = default;
+            if (!TlsFrameHelper.TryGetFrameHeader(input, ref header) ||
+                header.Type != TlsContentType.Handshake ||
+                input.Length < header.Length)
+            {
+                return;
+            }
+
+            int payloadLength = header.Length - TlsFrameHelper.HeaderSize;
+            if (payloadLength < 4)
+            {
+                return;
+            }
+
+            ReadOnlySpan<byte> payload = input.Slice(TlsFrameHelper.HeaderSize, payloadLength);
+            if (payload[0] != (byte)TlsHandshakeType.ClientHello)
+            {
+                return;
+            }
+
+            int bodyLength = (payload[1] << 16) | (payload[2] << 8) | payload[3];
+            int messageLength = 4 + bodyLength;
+            if (messageLength > payloadLength)
+            {
+                // The ClientHello spans more than one TLS record (rare: very large ECH/PQ hellos).
+                // Managed capture only reassembles a single record, so skip inspection here rather
+                // than surface truncated bytes — SChannel still completes the handshake normally.
+                _clientHelloInspected = true;
+                return;
+            }
+
+            _capturedClientHello = payload.Slice(0, messageLength).ToArray();
+            _clientHelloInspected = true;
+            suspend = TlsOperationStatus.NeedsClientHello;
+        }
+
+        partial void TryGetClientHelloBytes(ref ReadOnlySpan<byte> result)
+        {
+            if (_capturedClientHello is not null)
+            {
+                result = _capturedClientHello;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.cs
@@ -1907,6 +1907,32 @@ namespace System.Net.Security
         partial void TryFastHandshake(ref TlsOperationStatus? result);
         partial void TryFastRead(Span<byte> buffer, ref int bytesRead, ref TlsOperationStatus? result);
         partial void TryFastWrite(ReadOnlySpan<byte> buffer, ref int bytesWritten, ref TlsOperationStatus? result);
+        partial void TryGetClientHelloBytes(ref ReadOnlySpan<byte> result);
+
+        /// <summary>
+        /// Returns the raw ClientHello handshake message captured by OpenSSL, or an
+        /// empty span if none was captured (for example, when
+        /// <see cref="TlsContext.EnableClientHelloInspection"/> was not set, the handshake
+        /// has not yet reached ClientHello, or the platform does not support capture).
+        /// </summary>
+        /// <remarks>
+        /// Available after a handshake call returns
+        /// <see cref="TlsOperationStatus.NeedsClientHello"/>. The bytes are the TLS handshake
+        /// message (HandshakeType + 3-byte length + body), without the outer 5-byte TLS record
+        /// header. Intended for low-level callers that parse the ClientHello themselves
+        /// (e.g. SNI/ALPN routing).
+        /// <para>
+        /// The returned span is a zero-copy view over native memory owned by this session and
+        /// is only valid until the session is disposed. Copy it (for example with
+        /// <see cref="ReadOnlySpan{T}.ToArray"/>) if you need to retain the bytes.
+        /// </para>
+        /// </remarks>
+        public ReadOnlySpan<byte> GetClientHelloBytes()
+        {
+            ReadOnlySpan<byte> result = default;
+            TryGetClientHelloBytes(ref result);
+            return result;
+        }
 
         public void Dispose()
         {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.cs
@@ -664,6 +664,20 @@ namespace System.Net.Security
                             // ServerCertificateSelectionCallback).
                             return TlsOperationStatus.WantRead;
                         }
+
+                        // Windows/SChannel only: surface the raw ClientHello before SChannel
+                        // processes it. The ClientHello bytes are the inbound record the caller
+                        // just fed, so capture the handshake message and suspend once. Input is
+                        // left unconsumed (bytesConsumed stays 0) so the caller re-feeds the same
+                        // bytes on resume, exactly like the NeedsServerOptions detour. This is a
+                        // no-op on OpenSSL, where the native client_hello_cb performs the capture
+                        // inside AcceptSecurityContext and surfaces NeedsClientHello via the token.
+                        TlsOperationStatus? clientHelloSuspend = null;
+                        TryCaptureClientHelloForInspection(input, ref clientHelloSuspend);
+                        if (clientHelloSuspend is TlsOperationStatus chStatus)
+                        {
+                            return chStatus;
+                        }
                     }
 
                     EnsureCredentialsAcquired();
@@ -1927,6 +1941,7 @@ namespace System.Net.Security
         partial void TryFastRead(Span<byte> buffer, ref int bytesRead, ref TlsOperationStatus? result);
         partial void TryFastWrite(ReadOnlySpan<byte> buffer, ref int bytesWritten, ref TlsOperationStatus? result);
         partial void TryGetClientHelloBytes(ref ReadOnlySpan<byte> result);
+        partial void TryCaptureClientHelloForInspection(ReadOnlySpan<byte> input, ref TlsOperationStatus? suspend);
 
         /// <summary>
         /// Returns the raw ClientHello handshake message captured by OpenSSL, or an

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsSession.cs
@@ -67,6 +67,11 @@ namespace System.Net.Security
         // Set by SetClientCertificateContext after a WantCredentials suspension; consumed by
         // the next ProcessHandshake to allow an empty-input re-entry past the frame guard.
         private bool _resumeAfterCredentials;
+        // Set when ProcessHandshake returns NeedsClientHello (BIO mode); consumed by the next
+        // ProcessHandshake to allow an empty-input re-entry past the frame guard so the
+        // suspended SSL_do_handshake resumes and emits the ServerHello. The ClientHello bytes
+        // were already consumed into the BIO on the suspending call, so no re-feed is needed.
+        private bool _resumeAfterClientHello;
         // Intermediate certs the peer sent (chain elements minus the leaf). The platform-built
         // X509Chain itself is never surfaced to TlsSession callers; AcceptWithDefaultValidation
         // rebuilds a fresh chain from this collection at validation time.
@@ -601,7 +606,9 @@ namespace System.Net.Security
             bool isInitialClientCall = !_context.IsServer && _securityContext is null;
             bool isCredentialResume = _resumeAfterCredentials;
             _resumeAfterCredentials = false;
-            if (!isInitialClientCall && !isCredentialResume)
+            bool isClientHelloResume = _resumeAfterClientHello;
+            _resumeAfterClientHello = false;
+            if (!isInitialClientCall && !isCredentialResume && !isClientHelloResume)
             {
                 if (input.Length < TlsFrameHelper.HeaderSize)
                 {
@@ -748,7 +755,8 @@ namespace System.Net.Security
 
                 if (token.Failed &&
                     token.Status.ErrorCode != SecurityStatusPalErrorCode.CredentialsNeeded &&
-                    token.Status.ErrorCode != SecurityStatusPalErrorCode.CertValidationNeeded)
+                    token.Status.ErrorCode != SecurityStatusPalErrorCode.CertValidationNeeded &&
+                    token.Status.ErrorCode != SecurityStatusPalErrorCode.ClientHelloNeeded)
                 {
                     throw new AuthenticationException(SR.net_auth_SSPI, token.GetException());
                 }
@@ -756,6 +764,7 @@ namespace System.Net.Security
                 bool done = token.Status.ErrorCode == SecurityStatusPalErrorCode.OK;
                 bool needsCredentials = token.Status.ErrorCode == SecurityStatusPalErrorCode.CredentialsNeeded;
                 bool needsCertValidation = token.Status.ErrorCode == SecurityStatusPalErrorCode.CertValidationNeeded;
+                bool needsClientHello = token.Status.ErrorCode == SecurityStatusPalErrorCode.ClientHelloNeeded;
 
                 if (done)
                 {
@@ -794,6 +803,16 @@ namespace System.Net.Security
                 if (needsCredentials)
                 {
                     return TlsOperationStatus.WantCredentials;
+                }
+
+                if (needsClientHello)
+                {
+                    // The ClientHello bytes were already consumed into the BIO and captured
+                    // into the SSL object's ex_data. Arm an empty-input resume so the next
+                    // ProcessHandshake re-enters the suspended SSL_do_handshake (which then
+                    // emits the ServerHello) instead of being turned away by the frame guard.
+                    _resumeAfterClientHello = true;
+                    return TlsOperationStatus.NeedsClientHello;
                 }
 
                 // SChannel consumes one TLS record per AcceptSecurityContext/

--- a/src/libraries/System.Net.Security/src/System/Net/SecurityStatusPal.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/SecurityStatusPal.cs
@@ -35,6 +35,7 @@ namespace System.Net
         TryAgain,
         HandshakeStarted,
         CertValidationNeeded,
+        ClientHelloNeeded,
 
         // Errors
         OutOfMemory,

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -36,6 +36,8 @@
     <Compile Include="SslStreamMutualAuthenticationTest.cs" />
     <Compile Include="TlsSessionTests.cs"
              Condition="'$(TargetPlatformIdentifier)' == 'unix' or '$(TargetPlatformIdentifier)' == 'windows' or '$(TargetPlatformIdentifier)' == 'osx'" />
+    <Compile Include="TlsSessionAspNetCoreCallbacksTests.cs"
+             Condition="'$(TargetPlatformIdentifier)' == 'unix' or '$(TargetPlatformIdentifier)' == 'windows' or '$(TargetPlatformIdentifier)' == 'osx'" />
     <Compile Include="TransportContextTest.cs" />
     <!-- NegotiateAuthentication Tests -->
     <Compile Include="NegotiateAuthenticationKerberosTest.cs" />

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionAspNetCoreCallbacksTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionAspNetCoreCallbacksTests.cs
@@ -362,6 +362,157 @@ namespace System.Net.Security.Tests
                 $"SNI host '{serverName}' not found in captured ClientHello bytes.");
         }
 
+        // Same low-level raw ClientHello inspection as the fd-mode test above, but exercised through
+        // the BIO-mode path: the caller owns the transport and feeds ciphertext to
+        // ProcessHandshake(input, output, ...). The same OpenSSL ClientHello callback fires inside
+        // SSL_do_handshake regardless of transport, so ProcessHandshake surfaces
+        // TlsOperationStatus.NeedsClientHello exactly once with the identical raw bytes, then resumes
+        // (emitting the ServerHello) on the next call. Linux/OpenSSL only.
+        [Fact]
+        public async Task ClientHelloInspection_CapturesRawBytes_ViaTlsSession_BioMode()
+        {
+            if (!OperatingSystem.IsLinux() && !OperatingSystem.IsFreeBSD())
+            {
+                return; // Raw ClientHello capture is implemented only in the OpenSSL PAL.
+            }
+
+            using X509Certificate2 serverCert = TestCertificates.GetServerCertificate();
+            string serverName = serverCert.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+
+            (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
+            using (clientStream)
+            using (serverStream)
+            using (SslStream clientSsl = new SslStream(clientStream, leaveInnerStreamOpen: false, TestHelper.AllowAnyServerCertificate))
+            {
+                // ServerCertificate is supplied up-front so the session already has server options and
+                // goes straight to the handshake (no NeedsServerOptions detour), arming the SSL_CTX
+                // ClientHello callback before the first ProcessHandshake.
+                using TlsContext serverCtx = TlsContext.Create(new SslServerAuthenticationOptions
+                {
+                    ServerCertificate = serverCert,
+                    EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                });
+                serverCtx.EnableClientHelloInspection = true;
+
+                // BIO mode: no socket handle is passed, so the caller drives ciphertext through
+                // ProcessHandshake rather than letting OpenSSL own the socket.
+                using TlsSession server = TlsSession.Create(serverCtx);
+
+                Task clientHandshake = clientSsl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+                {
+                    TargetHost = serverName, // carried as the SNI host name in the ClientHello
+                    EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                    RemoteCertificateValidationCallback = TestHelper.AllowAnyServerCertificate,
+                });
+
+                int clientHelloSuspends = 0;
+                byte[]? capturedHello = null;
+
+                Task serverHandshake = Task.Run(async () =>
+                {
+                    byte[] netIn = ArrayPool<byte>.Shared.Rent(CipherBufSize);
+                    byte[] netOut = ArrayPool<byte>.Shared.Rent(CipherBufSize);
+                    int inUsed = 0;
+                    try
+                    {
+                        while (!server.IsHandshakeComplete)
+                        {
+                            TlsOperationStatus status = server.ProcessHandshake(
+                                netIn.AsSpan(0, inUsed),
+                                netOut,
+                                out int consumed,
+                                out int produced);
+
+                            if (consumed > 0)
+                            {
+                                if (consumed < inUsed)
+                                {
+                                    Buffer.BlockCopy(netIn, consumed, netIn, 0, inUsed - consumed);
+                                }
+                                inUsed -= consumed;
+                            }
+
+                            if (produced > 0)
+                            {
+                                await serverStream.WriteAsync(netOut.AsMemory(0, produced));
+                                await serverStream.FlushAsync();
+                            }
+
+                            switch (status)
+                            {
+                                case TlsOperationStatus.NeedsClientHello:
+                                    clientHelloSuspends++;
+                                    // The ClientHello was already consumed into the BIO and captured into
+                                    // ex_data; copy it out, then resume on the next ProcessHandshake (which
+                                    // re-enters the suspended SSL_do_handshake and emits the ServerHello).
+                                    ReadOnlySpan<byte> hello = server.GetClientHelloBytes();
+                                    capturedHello = hello.ToArray();
+                                    continue;
+
+                                case TlsOperationStatus.NeedsCertificateValidation:
+                                    server.AcceptWithDefaultValidation();
+                                    continue;
+
+                                case TlsOperationStatus.Complete:
+                                    continue;
+
+                                case TlsOperationStatus.WantWrite:
+                                    while (server.HasPendingOutput)
+                                    {
+                                        server.DrainPendingOutput(netOut, out int extra);
+                                        if (extra > 0)
+                                        {
+                                            await serverStream.WriteAsync(netOut.AsMemory(0, extra));
+                                            await serverStream.FlushAsync();
+                                        }
+                                    }
+                                    continue;
+
+                                case TlsOperationStatus.WantRead:
+                                    int r = await serverStream.ReadAsync(netIn.AsMemory(inUsed));
+                                    if (r == 0)
+                                    {
+                                        throw new IOException("Unexpected EOF during handshake.");
+                                    }
+                                    inUsed += r;
+                                    continue;
+
+                                case TlsOperationStatus.Closed:
+                                    throw new IOException("Peer closed connection during handshake.");
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(netIn);
+                        ArrayPool<byte>.Shared.Return(netOut);
+                    }
+                });
+
+                await Task.WhenAll(clientHandshake, serverHandshake).WaitAsync(TimeSpan.FromSeconds(30));
+
+                Assert.True(server.IsHandshakeComplete);
+                Assert.True(clientSsl.IsAuthenticated);
+
+                // The handshake paused exactly once at ClientHello and produced bytes.
+                Assert.Equal(1, clientHelloSuspends);
+                Assert.NotNull(capturedHello);
+                Assert.NotEmpty(capturedHello!);
+
+                // First byte is the TLS HandshakeType for ClientHello (1), with no outer 5-byte record
+                // header, and the 3-byte length prefix matches the remaining body length.
+                Assert.Equal(1, capturedHello![0]);
+                int body = (capturedHello[1] << 16) | (capturedHello[2] << 8) | capturedHello[3];
+                Assert.Equal(capturedHello.Length, 4 + body);
+
+                // The SNI host the client advertised appears verbatim in the raw bytes, proving these
+                // are the real ClientHello the peer sent (the routing info Kestrel would parse).
+                byte[] sniBytes = Encoding.ASCII.GetBytes(serverName);
+                Assert.True(capturedHello.AsSpan().IndexOf(sniBytes) >= 0,
+                    $"SNI host '{serverName}' not found in captured ClientHello bytes.");
+            }
+        }
+
         // ── Server-side handshake driver (TlsSession only, no SslStream on this side) ──────
 
         // Drives the server TlsSession over <paramref name="transport"/> until the handshake

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionAspNetCoreCallbacksTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionAspNetCoreCallbacksTests.cs
@@ -513,6 +513,153 @@ namespace System.Net.Security.Tests
             }
         }
 
+        // Same low-level raw ClientHello inspection, exercised on Windows/SChannel through the BIO-mode
+        // ProcessHandshake path. SChannel has no native ClientHello callback, but in the BIO model the
+        // caller feeds the ClientHello bytes into the session, so the raw message is the first inbound
+        // record. TlsSession captures it in managed code, surfaces TlsOperationStatus.NeedsClientHello
+        // once (leaving the bytes unconsumed), and resumes when the caller re-feeds them — producing the
+        // identical handshake-message bytes the OpenSSL PAL returns. Windows only; TLS 1.3 because the
+        // PoC's SChannel server path cannot acquire TLS 1.2 server credentials (see Tls12SkippedOnWindows).
+        [Fact]
+        public async Task ClientHelloInspection_CapturesRawBytes_ViaTlsSession_BioMode_Windows()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return; // SChannel managed ClientHello capture is the Windows-only path.
+            }
+
+            using X509Certificate2 serverCert = TestCertificates.GetServerCertificate();
+            string serverName = serverCert.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+
+            (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
+            using (clientStream)
+            using (serverStream)
+            using (SslStream clientSsl = new SslStream(clientStream, leaveInnerStreamOpen: false, TestHelper.AllowAnyServerCertificate))
+            {
+                using TlsContext serverCtx = TlsContext.Create(new SslServerAuthenticationOptions
+                {
+                    ServerCertificate = serverCert,
+                    EnabledSslProtocols = SslProtocols.Tls13,
+                });
+                serverCtx.EnableClientHelloInspection = true;
+
+                // BIO mode: no socket handle, so the caller drives ciphertext through ProcessHandshake.
+                using TlsSession server = TlsSession.Create(serverCtx);
+
+                Task clientHandshake = clientSsl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+                {
+                    TargetHost = serverName,
+                    EnabledSslProtocols = SslProtocols.Tls13,
+                    RemoteCertificateValidationCallback = TestHelper.AllowAnyServerCertificate,
+                });
+
+                int clientHelloSuspends = 0;
+                byte[]? capturedHello = null;
+
+                Task serverHandshake = Task.Run(async () =>
+                {
+                    byte[] netIn = ArrayPool<byte>.Shared.Rent(CipherBufSize);
+                    byte[] netOut = ArrayPool<byte>.Shared.Rent(CipherBufSize);
+                    int inUsed = 0;
+                    try
+                    {
+                        while (!server.IsHandshakeComplete)
+                        {
+                            TlsOperationStatus status = server.ProcessHandshake(
+                                netIn.AsSpan(0, inUsed),
+                                netOut,
+                                out int consumed,
+                                out int produced);
+
+                            if (consumed > 0)
+                            {
+                                if (consumed < inUsed)
+                                {
+                                    Buffer.BlockCopy(netIn, consumed, netIn, 0, inUsed - consumed);
+                                }
+                                inUsed -= consumed;
+                            }
+
+                            if (produced > 0)
+                            {
+                                await serverStream.WriteAsync(netOut.AsMemory(0, produced));
+                                await serverStream.FlushAsync();
+                            }
+
+                            switch (status)
+                            {
+                                case TlsOperationStatus.NeedsClientHello:
+                                    clientHelloSuspends++;
+                                    // Managed capture: read the raw bytes, then resume. The ClientHello was
+                                    // left unconsumed (consumed == 0), so the same bytes are re-fed to
+                                    // SChannel on the next ProcessHandshake, which emits the ServerHello.
+                                    ReadOnlySpan<byte> hello = server.GetClientHelloBytes();
+                                    capturedHello = hello.ToArray();
+                                    continue;
+
+                                case TlsOperationStatus.NeedsCertificateValidation:
+                                    server.AcceptWithDefaultValidation();
+                                    continue;
+
+                                case TlsOperationStatus.Complete:
+                                    continue;
+
+                                case TlsOperationStatus.WantWrite:
+                                    while (server.HasPendingOutput)
+                                    {
+                                        server.DrainPendingOutput(netOut, out int extra);
+                                        if (extra > 0)
+                                        {
+                                            await serverStream.WriteAsync(netOut.AsMemory(0, extra));
+                                            await serverStream.FlushAsync();
+                                        }
+                                    }
+                                    continue;
+
+                                case TlsOperationStatus.WantRead:
+                                    int r = await serverStream.ReadAsync(netIn.AsMemory(inUsed));
+                                    if (r == 0)
+                                    {
+                                        throw new IOException("Unexpected EOF during handshake.");
+                                    }
+                                    inUsed += r;
+                                    continue;
+
+                                case TlsOperationStatus.Closed:
+                                    throw new IOException("Peer closed connection during handshake.");
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(netIn);
+                        ArrayPool<byte>.Shared.Return(netOut);
+                    }
+                });
+
+                await Task.WhenAll(clientHandshake, serverHandshake).WaitAsync(TimeSpan.FromSeconds(30));
+
+                Assert.True(server.IsHandshakeComplete);
+                Assert.True(clientSsl.IsAuthenticated);
+
+                // Paused exactly once at ClientHello and produced bytes.
+                Assert.Equal(1, clientHelloSuspends);
+                Assert.NotNull(capturedHello);
+                Assert.NotEmpty(capturedHello!);
+
+                // First byte is HandshakeType ClientHello (1), no outer 5-byte record header, and the
+                // 3-byte length prefix matches the remaining body — identical shape to the OpenSSL path.
+                Assert.Equal(1, capturedHello![0]);
+                int body = (capturedHello[1] << 16) | (capturedHello[2] << 8) | capturedHello[3];
+                Assert.Equal(capturedHello.Length, 4 + body);
+
+                // The SNI host the client advertised appears verbatim in the raw bytes.
+                byte[] sniBytes = Encoding.ASCII.GetBytes(serverName);
+                Assert.True(capturedHello.AsSpan().IndexOf(sniBytes) >= 0,
+                    $"SNI host '{serverName}' not found in captured ClientHello bytes.");
+            }
+        }
+
         // ── Server-side handshake driver (TlsSession only, no SslStream on this side) ──────
 
         // Drives the server TlsSession over <paramref name="transport"/> until the handshake

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionAspNetCoreCallbacksTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionAspNetCoreCallbacksTests.cs
@@ -1,0 +1,448 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.IO;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net.Test.Common;
+using Xunit;
+
+using TestCertificates = System.Net.Test.Common.Configuration.Certificates;
+
+namespace System.Net.Security.Tests
+{
+    // Proves that the two server-side TLS callbacks ASP.NET Core Kestrel exposes today can be
+    // supported on top of the standalone TlsSession / TlsContext state machine. The server side is
+    // driven entirely by TlsSession (no SslStream) — the same role Kestrel's "DirectSsl" transport
+    // plays — while a real SslStream stands in for the connecting client.
+    //
+    //   ASP.NET Core surface (HttpsConnectionAdapterOptions)        runtime option it maps to
+    //   ---------------------------------------------------------   ----------------------------------------------------
+    //   ServerCertificateSelector(connection, hostName) => cert  -> SslServerAuthenticationOptions.ServerCertificateSelectionCallback
+    //   ClientCertificateValidation(cert, chain, errors) => bool -> SslServerAuthenticationOptions.RemoteCertificateValidationCallback
+    //                                                               (with ClientCertificateRequired = true)
+    //
+    // Both are plain delegates carried on SslServerAuthenticationOptions. TlsContext.Create copies
+    // them into its internal options bag, so NO new runtime API is required to honor either one:
+    //   * ServerCertificateSelectionCallback runs inline while the server resolves its certificate
+    //     from the ClientHello SNI (TlsSession.ResolveServerCertificateFromClientHello).
+    //   * RemoteCertificateValidationCallback runs when the server validates the peer (client)
+    //     certificate. TlsSession surfaces this as a NeedsCertificateValidation suspension;
+    //     AcceptWithDefaultValidation drives the user callback (SslStream.VerifyRemoteCertificateCore)
+    //     and applies its verdict.
+    //
+    // Tls12SkippedOnWindows: TLS 1.2 cases are skipped on Windows because TlsSession's server-side
+    // SChannel path cannot acquire TLS 1.2 server credentials in this PoC — AcquireCredentialsHandle
+    // fails with "no common algorithm". This is a pre-existing PoC limitation, not a defect in these
+    // tests: the PoC's own ServerSession_RequestClientCertificate_Tls12_ProducesHandshakeBytes and
+    // TwoSessions_HandshakeAndPingPong_InMemory_Succeeds(Tls12) fail identically on Windows, while
+    // their TLS 1.3 counterparts pass. The DirectSsl transport targets Linux/OpenSSL, where TLS 1.2
+    // negotiates correctly, so TLS 1.2 is exercised on non-Windows only.
+    [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.FreeBSD | TestPlatforms.Windows | TestPlatforms.OSX)]
+    public class TlsSessionAspNetCoreCallbacksTests
+    {
+        private const int CipherBufSize = 32 * 1024;
+
+        // ASP.NET Core: options.ServerCertificateSelector = (connectionContext, hostName) => cert;
+        [Theory]
+        [InlineData(SslProtocols.Tls12)]
+        [InlineData(SslProtocols.Tls13)]
+        public async Task ServerCertificateSelector_IsHonored_ViaTlsSession(SslProtocols protocol)
+        {
+            if (protocol == SslProtocols.Tls13 && OperatingSystem.IsMacOS())
+            {
+                return; // SecureTransport (legacy macOS backend used here) does not implement TLS 1.3.
+            }
+
+            if (protocol == SslProtocols.Tls12 && OperatingSystem.IsWindows())
+            {
+                return; // See note on Tls12SkippedOnWindows.
+            }
+
+            using X509Certificate2 serverCert = TestCertificates.GetServerCertificate();
+            string serverName = serverCert.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+
+            int selectorCalls = 0;
+            string? observedSni = null;
+
+            (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
+            using (clientStream)
+            using (serverStream)
+            using (SslStream clientSsl = new SslStream(clientStream, leaveInnerStreamOpen: false, TestHelper.AllowAnyServerCertificate))
+            {
+                using TlsContext serverCtx = TlsContext.Create(new SslServerAuthenticationOptions
+                {
+                    EnabledSslProtocols = protocol,
+                    // Stand-in for HttpsConnectionAdapterOptions.ServerCertificateSelector: pick the cert
+                    // based on the SNI host name advertised in the ClientHello.
+                    ServerCertificateSelectionCallback = (sender, hostName) =>
+                    {
+                        selectorCalls++;
+                        observedSni = hostName;
+                        Assert.IsType<TlsSession>(sender);
+                        return serverCert;
+                    },
+                });
+                using TlsSession server = TlsSession.Create(serverCtx);
+
+                Task clientHandshake = clientSsl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+                {
+                    TargetHost = serverName,
+                    EnabledSslProtocols = protocol,
+                    RemoteCertificateValidationCallback = TestHelper.AllowAnyServerCertificate,
+                });
+                Task serverHandshake = DriveServerHandshakeAsync(server, serverStream);
+
+                await Task.WhenAll(clientHandshake, serverHandshake).WaitAsync(TimeSpan.FromSeconds(30));
+
+                Assert.True(server.IsHandshakeComplete);
+                Assert.True(clientSsl.IsAuthenticated);
+                Assert.Equal(1, selectorCalls);
+                Assert.Equal(serverName, observedSni);
+
+                // The certificate the selector returned is exactly the one the client received.
+                Assert.NotNull(clientSsl.RemoteCertificate);
+                Assert.Equal(serverCert.Thumbprint, new X509Certificate2(clientSsl.RemoteCertificate).Thumbprint);
+            }
+        }
+
+        // ASP.NET Core: options.ClientCertificateValidation = (cert, chain, errors) => true; (accept path)
+        [Theory]
+        [InlineData(SslProtocols.Tls12)]
+        [InlineData(SslProtocols.Tls13)]
+        public async Task ClientCertificateValidation_Accept_IsHonored_ViaTlsSession(SslProtocols protocol)
+        {
+            if (protocol == SslProtocols.Tls13 && OperatingSystem.IsMacOS())
+            {
+                return;
+            }
+
+            if (protocol == SslProtocols.Tls12 && OperatingSystem.IsWindows())
+            {
+                return; // See note on Tls12SkippedOnWindows.
+            }
+
+            using X509Certificate2 serverCert = TestCertificates.GetServerCertificate();
+            using X509Certificate2 clientCert = TestCertificates.GetClientCertificate();
+            string serverName = serverCert.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+
+            int validatorCalls = 0;
+            X509Certificate2? observedClientCert = null;
+
+            (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
+            using (clientStream)
+            using (serverStream)
+            using (SslStream clientSsl = new SslStream(clientStream, leaveInnerStreamOpen: false, TestHelper.AllowAnyServerCertificate))
+            {
+                using TlsContext serverCtx = TlsContext.Create(new SslServerAuthenticationOptions
+                {
+                    ServerCertificate = serverCert,
+                    EnabledSslProtocols = protocol,
+                    ClientCertificateRequired = true,
+                    // Stand-in for HttpsConnectionAdapterOptions.ClientCertificateValidation.
+                    RemoteCertificateValidationCallback = (sender, cert, chain, errors) =>
+                    {
+                        validatorCalls++;
+                        observedClientCert = cert as X509Certificate2;
+                        return true; // accept
+                    },
+                });
+                using TlsSession server = TlsSession.Create(serverCtx);
+
+                Task clientHandshake = clientSsl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+                {
+                    TargetHost = serverName,
+                    EnabledSslProtocols = protocol,
+                    ClientCertificates = new X509CertificateCollection { clientCert },
+                    RemoteCertificateValidationCallback = TestHelper.AllowAnyServerCertificate,
+                });
+                Task serverHandshake = DriveServerHandshakeAsync(server, serverStream);
+
+                await Task.WhenAll(clientHandshake, serverHandshake).WaitAsync(TimeSpan.FromSeconds(30));
+
+                Assert.True(server.IsHandshakeComplete);
+                Assert.Equal(1, validatorCalls);
+                Assert.NotNull(observedClientCert);
+                Assert.Equal(clientCert.Thumbprint, observedClientCert!.Thumbprint);
+
+                // The server actually received the client certificate it validated.
+                using X509Certificate2? remote = server.GetRemoteCertificate();
+                Assert.NotNull(remote);
+                Assert.Equal(clientCert.Thumbprint, remote!.Thumbprint);
+            }
+        }
+
+        // ASP.NET Core: options.ClientCertificateValidation = (cert, chain, errors) => false; (reject path)
+        [Theory]
+        [InlineData(SslProtocols.Tls12)]
+        [InlineData(SslProtocols.Tls13)]
+        public async Task ClientCertificateValidation_Reject_FaultsHandshake_ViaTlsSession(SslProtocols protocol)
+        {
+            if (protocol == SslProtocols.Tls13 && OperatingSystem.IsMacOS())
+            {
+                return;
+            }
+
+            if (protocol == SslProtocols.Tls12 && OperatingSystem.IsWindows())
+            {
+                return; // See note on Tls12SkippedOnWindows.
+            }
+
+            using X509Certificate2 serverCert = TestCertificates.GetServerCertificate();
+            using X509Certificate2 clientCert = TestCertificates.GetClientCertificate();
+            string serverName = serverCert.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+
+            int validatorCalls = 0;
+
+            (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
+            using (clientStream)
+            using (serverStream)
+            using (SslStream clientSsl = new SslStream(clientStream, leaveInnerStreamOpen: false, TestHelper.AllowAnyServerCertificate))
+            {
+                using TlsContext serverCtx = TlsContext.Create(new SslServerAuthenticationOptions
+                {
+                    ServerCertificate = serverCert,
+                    EnabledSslProtocols = protocol,
+                    ClientCertificateRequired = true,
+                    // Reject the client certificate unconditionally, even though the chain is clean.
+                    RemoteCertificateValidationCallback = (sender, cert, chain, errors) =>
+                    {
+                        validatorCalls++;
+                        return false; // reject
+                    },
+                });
+                using TlsSession server = TlsSession.Create(serverCtx);
+
+                Task clientHandshake = clientSsl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+                {
+                    TargetHost = serverName,
+                    EnabledSslProtocols = protocol,
+                    ClientCertificates = new X509CertificateCollection { clientCert },
+                    RemoteCertificateValidationCallback = TestHelper.AllowAnyServerCertificate,
+                });
+                Task serverHandshake = DriveServerHandshakeAsync(server, serverStream);
+
+                // The server exchanges all TLS records (the client receives the server Finished and
+                // completes), then runs the validator, which rejects. AcceptWithDefaultValidation
+                // records the rejection without throwing, so the driver returns normally.
+                await serverHandshake.WaitAsync(TimeSpan.FromSeconds(30));
+
+                // The validator ran exactly once with the client certificate.
+                Assert.Equal(1, validatorCalls);
+
+                // The false verdict faulted the session: any subsequent operation throws, proving the
+                // rejection was honored (mirrors SslStream, which would have failed authentication).
+                Assert.Throws<AuthenticationException>(() =>
+                    server.Encrypt("x"u8.ToArray(), new byte[CipherBufSize], out _, out _));
+
+                // Drain the client side so the connection tears down cleanly; its outcome is not asserted.
+                try
+                {
+                    await clientHandshake.WaitAsync(TimeSpan.FromSeconds(5));
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        // ASP.NET Core "DirectSsl": low-level raw ClientHello inspection. With
+        // TlsContext.EnableClientHelloInspection set, the server TlsSession pauses the handshake
+        // once at ClientHello time (TlsOperationStatus.NeedsClientHello) and hands the caller the
+        // raw ClientHello handshake bytes OpenSSL received off the socket, before any certificate
+        // or server-option decision. Kestrel parses these itself (SNI/ALPN routing) and resumes.
+        //
+        // This is the fd-mode path: OpenSSL owns the socket (SSL_set_fd) and the caller never sees
+        // the wire bytes except through this callback — the "we just listen, OpenSSL hands us the
+        // data" semantics. Linux/OpenSSL only: the capture lives in the OpenSSL PAL; SChannel and
+        // SecureTransport do not implement it.
+        [Fact]
+        public async Task ClientHelloInspection_CapturesRawBytes_ViaTlsSession_FdMode()
+        {
+            if (!OperatingSystem.IsLinux() && !OperatingSystem.IsFreeBSD())
+            {
+                return; // Raw ClientHello capture is implemented only in the OpenSSL PAL.
+            }
+
+            using X509Certificate2 serverCert = TestCertificates.GetServerCertificate();
+            string serverName = serverCert.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(1);
+            int port = ((IPEndPoint)listener.LocalEndPoint!).Port;
+
+            using Socket clientUnderlying = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);
+            Socket serverSocket = await listener.AcceptAsync();
+            await connect;
+
+            // TlsSession fd-mode contract requires a non-blocking socket.
+            serverSocket.Blocking = false;
+            SafeSocketHandle serverHandle = serverSocket.SafeHandle;
+
+            using TlsContext serverCtx = TlsContext.Create(new SslServerAuthenticationOptions
+            {
+                ServerCertificate = serverCert,
+                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+            });
+            // Opt in (before the first handshake, so the SSL_CTX is armed): pause at ClientHello
+            // and surface the raw bytes.
+            serverCtx.EnableClientHelloInspection = true;
+
+            using TlsSession server = TlsSession.Create(serverCtx, serverHandle);
+
+            using SslStream clientSsl = new SslStream(new NetworkStream(clientUnderlying, ownsSocket: false), leaveInnerStreamOpen: false, TestHelper.AllowAnyServerCertificate);
+            Task clientHandshake = clientSsl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+            {
+                TargetHost = serverName, // carried as the SNI host name in the ClientHello
+                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                RemoteCertificateValidationCallback = TestHelper.AllowAnyServerCertificate,
+            });
+
+            int clientHelloSuspends = 0;
+            byte[]? capturedHello = null;
+
+            Task serverHandshake = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    TlsOperationStatus s = server.Handshake();
+                    if (s == TlsOperationStatus.Complete)
+                    {
+                        return;
+                    }
+                    if (s == TlsOperationStatus.NeedsClientHello)
+                    {
+                        clientHelloSuspends++;
+                        // Zero-copy view over native memory owned by the session; copy it out before
+                        // resuming so the assertions below can run after the handshake completes.
+                        ReadOnlySpan<byte> hello = server.GetClientHelloBytes();
+                        capturedHello = hello.ToArray();
+                        continue; // next Handshake() resumes (the RETRY is consumed once)
+                    }
+                    if (s == TlsOperationStatus.NeedsCertificateValidation)
+                    {
+                        server.AcceptWithDefaultValidation();
+                        continue;
+                    }
+                    if (s == TlsOperationStatus.WantRead || s == TlsOperationStatus.WantWrite)
+                    {
+                        await Task.Delay(5);
+                        continue;
+                    }
+                    throw new InvalidOperationException($"Unexpected handshake status: {s}");
+                }
+            });
+
+            await Task.WhenAll(clientHandshake, serverHandshake).WaitAsync(TimeSpan.FromSeconds(30));
+
+            Assert.True(server.IsHandshakeComplete);
+            Assert.True(clientSsl.IsAuthenticated);
+
+            // The handshake paused exactly once at ClientHello and produced bytes.
+            Assert.Equal(1, clientHelloSuspends);
+            Assert.NotNull(capturedHello);
+            Assert.NotEmpty(capturedHello!);
+
+            // First byte is the TLS HandshakeType for ClientHello (1), with no outer 5-byte record
+            // header, and the 3-byte length prefix matches the remaining body length.
+            Assert.Equal(1, capturedHello![0]);
+            int body = (capturedHello[1] << 16) | (capturedHello[2] << 8) | capturedHello[3];
+            Assert.Equal(capturedHello.Length, 4 + body);
+
+            // The SNI host the client advertised appears verbatim in the raw bytes, proving these are
+            // the real ClientHello the peer sent (the routing info Kestrel would parse).
+            byte[] sniBytes = Encoding.ASCII.GetBytes(serverName);
+            Assert.True(capturedHello.AsSpan().IndexOf(sniBytes) >= 0,
+                $"SNI host '{serverName}' not found in captured ClientHello bytes.");
+        }
+
+        // ── Server-side handshake driver (TlsSession only, no SslStream on this side) ──────
+
+        // Drives the server TlsSession over <paramref name="transport"/> until the handshake
+        // completes. Honors the peer-certificate verdict via AcceptWithDefaultValidation — this is
+        // where the server's RemoteCertificateValidationCallback (ASP.NET Core ClientCertificateValidation)
+        // runs. A rejecting callback does not throw here; it faults the session so the next
+        // Encrypt/Decrypt throws AuthenticationException.
+        private static async Task DriveServerHandshakeAsync(TlsSession session, Stream transport)
+        {
+            byte[] netIn = ArrayPool<byte>.Shared.Rent(CipherBufSize);
+            byte[] netOut = ArrayPool<byte>.Shared.Rent(CipherBufSize);
+            int inUsed = 0;
+
+            try
+            {
+                while (!session.IsHandshakeComplete)
+                {
+                    TlsOperationStatus status = session.ProcessHandshake(
+                        netIn.AsSpan(0, inUsed),
+                        netOut,
+                        out int consumed,
+                        out int produced);
+
+                    if (consumed > 0)
+                    {
+                        if (consumed < inUsed)
+                        {
+                            Buffer.BlockCopy(netIn, consumed, netIn, 0, inUsed - consumed);
+                        }
+                        inUsed -= consumed;
+                    }
+
+                    if (produced > 0)
+                    {
+                        await transport.WriteAsync(netOut.AsMemory(0, produced));
+                        await transport.FlushAsync();
+                    }
+
+                    switch (status)
+                    {
+                        case TlsOperationStatus.Complete:
+                            continue;
+
+                        case TlsOperationStatus.NeedsCertificateValidation:
+                            // Runs the user RemoteCertificateValidationCallback and applies its verdict.
+                            // On reject it records the fault (it does not throw here); the session is
+                            // left faulted so any later Encrypt/Decrypt throws AuthenticationException.
+                            session.AcceptWithDefaultValidation();
+                            continue;
+
+                        case TlsOperationStatus.WantWrite:
+                            while (session.HasPendingOutput)
+                            {
+                                session.DrainPendingOutput(netOut, out int extra);
+                                if (extra > 0)
+                                {
+                                    await transport.WriteAsync(netOut.AsMemory(0, extra));
+                                    await transport.FlushAsync();
+                                }
+                            }
+                            continue;
+
+                        case TlsOperationStatus.WantRead:
+                            int r = await transport.ReadAsync(netIn.AsMemory(inUsed));
+                            if (r == 0)
+                            {
+                                throw new IOException("Unexpected EOF during handshake.");
+                            }
+                            inUsed += r;
+                            continue;
+
+                        case TlsOperationStatus.Closed:
+                            throw new IOException("Peer closed connection during handshake.");
+                    }
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(netIn);
+                ArrayPool<byte>.Shared.Return(netOut);
+            }
+        }
+    }
+}

--- a/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
@@ -412,6 +412,8 @@ static const Entry s_cryptoNative[] =
     DllImportEntry(CryptoNative_SslSetFd)
     DllImportEntry(CryptoNative_SslDoHandshake)
     DllImportEntry(CryptoNative_SslSetClientCertCallback)
+    DllImportEntry(CryptoNative_SslCtxSetClientHelloCallback)
+    DllImportEntry(CryptoNative_SslGetClientHelloData)
     DllImportEntry(CryptoNative_SslSetPostHandshakeAuth)
     DllImportEntry(CryptoNative_SslSetConnectState)
     DllImportEntry(CryptoNative_SslSetData)

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -701,11 +701,13 @@ extern bool g_libSslUses32BitTime;
     REQUIRED_FUNCTION(SSL_CTX_remove_session) \
     LIGHTUP_FUNCTION(SSL_CTX_set_alpn_protos) \
     LIGHTUP_FUNCTION(SSL_CTX_set_alpn_select_cb) \
+    LIGHTUP_FUNCTION(SSL_CTX_set_client_hello_cb) \
     REQUIRED_FUNCTION(SSL_CTX_set_cipher_list) \
     LIGHTUP_FUNCTION(SSL_CTX_set_ciphersuites) \
     REQUIRED_FUNCTION(SSL_CTX_set_client_cert_cb) \
     REQUIRED_FUNCTION(SSL_CTX_set_ex_data) \
     REQUIRED_FUNCTION(SSL_CTX_set_keylog_callback) \
+    REQUIRED_FUNCTION(SSL_CTX_set_msg_callback) \
     REQUIRED_FUNCTION(SSL_CTX_set_quiet_shutdown) \
     REQUIRED_FUNCTION(SSL_CTX_set_options) \
     REQUIRED_FUNCTION(SSL_CTX_set_security_level) \
@@ -1286,12 +1288,14 @@ extern TYPEOF(OPENSSL_gmtime)* OPENSSL_gmtime_ptr;
 #define SSL_CTX_remove_session SSL_CTX_remove_session_ptr
 #define SSL_CTX_set_alpn_protos SSL_CTX_set_alpn_protos_ptr
 #define SSL_CTX_set_alpn_select_cb SSL_CTX_set_alpn_select_cb_ptr
+#define SSL_CTX_set_client_hello_cb SSL_CTX_set_client_hello_cb_ptr
 #define SSL_CTX_set_cipher_list SSL_CTX_set_cipher_list_ptr
 #define SSL_CTX_set_ciphersuites SSL_CTX_set_ciphersuites_ptr
 #define SSL_CTX_set_client_cert_cb SSL_CTX_set_client_cert_cb_ptr
 #define SSL_CTX_set_ex_data SSL_CTX_set_ex_data_ptr
 #define SSL_CTX_set_options SSL_CTX_set_options_ptr
 #define SSL_CTX_set_keylog_callback SSL_CTX_set_keylog_callback_ptr
+#define SSL_CTX_set_msg_callback SSL_CTX_set_msg_callback_ptr
 #define SSL_CTX_set_quiet_shutdown SSL_CTX_set_quiet_shutdown_ptr
 #define SSL_CTX_set_security_level SSL_CTX_set_security_level_ptr
 #define SSL_CTX_set_session_id_context SSL_CTX_set_session_id_context_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -1106,6 +1106,177 @@ void CryptoNative_SslSetClientCertCallback(SSL* ssl, int set)
     SSL_set_cert_cb(ssl, set ? client_certificate_cb : NULL, NULL);
 }
 
+// ── Raw ClientHello inspection ───────────────────────────────────────────────
+//
+// Surfaces the raw ClientHello bytes OpenSSL received off the wire to managed
+// code, and pauses the handshake once at ClientHello time so managed code can
+// observe them (and resolve server options) before any certificate decision.
+//
+// Two native callbacks cooperate, both installed on the SSL_CTX:
+//   * msg_callback captures the inbound ClientHello handshake message as soon as
+//     it is read - this is the only hook that exposes the whole raw message
+//     (the SSL_client_hello_get0_* accessors only expose parsed fields).
+//   * client_hello_cb fires immediately after, and returns SSL_CLIENT_HELLO_RETRY
+//     exactly once to suspend the handshake (SSL_do_handshake then returns
+//     SSL_ERROR_WANT_CLIENT_HELLO_CB). On the resume call it returns SUCCESS.
+//
+// Per-SSL state is kept in ex_data so it is naturally freed on SSL_free and so
+// the captured bytes remain valid between suspend and resume (and until the
+// managed side has copied them).
+
+typedef struct ClientHelloCapture
+{
+    uint8_t* data;
+    int32_t length;
+    int32_t suspended; // 0 = not yet suspended, 1 = already retried once (resume)
+} ClientHelloCapture;
+
+static int g_clientHelloExIndex = -1;
+
+static void ClientHelloCapture_Free(void* parent, void* ptr, CRYPTO_EX_DATA* ad, int idx, long argl, void* argp)
+{
+    (void)parent; (void)ad; (void)idx; (void)argl; (void)argp;
+    ClientHelloCapture* cap = (ClientHelloCapture*)ptr;
+    if (cap != NULL)
+    {
+        if (cap->data != NULL)
+        {
+            OPENSSL_free(cap->data);
+        }
+        OPENSSL_free(cap);
+    }
+}
+
+static ClientHelloCapture* GetOrCreateClientHelloCapture(SSL* ssl)
+{
+    if (g_clientHelloExIndex < 0)
+    {
+        return NULL;
+    }
+
+    ClientHelloCapture* cap = (ClientHelloCapture*)SSL_get_ex_data(ssl, g_clientHelloExIndex);
+    if (cap == NULL)
+    {
+        cap = (ClientHelloCapture*)OPENSSL_malloc(sizeof(ClientHelloCapture));
+        if (cap == NULL)
+        {
+            return NULL;
+        }
+        memset(cap, 0, sizeof(ClientHelloCapture));
+        if (SSL_set_ex_data(ssl, g_clientHelloExIndex, cap) != 1)
+        {
+            OPENSSL_free(cap);
+            return NULL;
+        }
+    }
+    return cap;
+}
+
+static void ClientHelloMsgCallback(int write_p, int version, int content_type, const void* buf, size_t len, SSL* ssl, void* arg)
+{
+    (void)version; (void)arg;
+
+    // Only the inbound (write_p == 0) ClientHello handshake message. The first
+    // byte of a handshake message is its HandshakeType; ClientHello == 1.
+    if (write_p != 0 || content_type != SSL3_RT_HANDSHAKE || len < 1)
+    {
+        return;
+    }
+    if (((const uint8_t*)buf)[0] != SSL3_MT_CLIENT_HELLO)
+    {
+        return;
+    }
+
+    ClientHelloCapture* cap = GetOrCreateClientHelloCapture(ssl);
+    if (cap == NULL || cap->data != NULL)
+    {
+        // Already captured (e.g. HelloRetryRequest second ClientHello) - keep the first.
+        return;
+    }
+
+    cap->data = (uint8_t*)OPENSSL_malloc(len);
+    if (cap->data == NULL)
+    {
+        return;
+    }
+    memcpy(cap->data, buf, len);
+    cap->length = (int32_t)len;
+}
+
+static int ClientHelloCallback(SSL* ssl, int* al, void* arg)
+{
+    (void)al; (void)arg;
+
+    ClientHelloCapture* cap = GetOrCreateClientHelloCapture(ssl);
+    if (cap == NULL)
+    {
+        // Out of memory or no ex_data index - don't wedge the handshake.
+        return SSL_CLIENT_HELLO_SUCCESS;
+    }
+
+    if (cap->suspended == 0)
+    {
+        cap->suspended = 1;
+        // Suspend: SSL_do_handshake returns with SSL_ERROR_WANT_CLIENT_HELLO_CB.
+        return SSL_CLIENT_HELLO_RETRY;
+    }
+
+    return SSL_CLIENT_HELLO_SUCCESS;
+}
+
+void CryptoNative_SslCtxSetClientHelloCallback(SSL_CTX* ctx, int32_t enable)
+{
+    // void shim functions don't lead to exceptions, so skip the unconditional error clearing.
+
+    if (!enable)
+    {
+        return;
+    }
+
+    if (!API_EXISTS(SSL_CTX_set_client_hello_cb))
+    {
+        // OpenSSL < 1.1.1 - ClientHello callback unavailable.
+        return;
+    }
+
+    if (g_clientHelloExIndex < 0)
+    {
+        // CRYPTO_EX_INDEX_SSL == 0. The free function releases the per-SSL capture
+        // automatically on SSL_free.
+        int idx = CRYPTO_get_ex_new_index(0, 0, NULL, NULL, NULL, ClientHelloCapture_Free);
+        if (idx < 0)
+        {
+            return;
+        }
+        g_clientHelloExIndex = idx;
+    }
+
+    SSL_CTX_set_msg_callback(ctx, ClientHelloMsgCallback);
+    SSL_CTX_set_client_hello_cb(ctx, ClientHelloCallback, NULL);
+}
+
+int32_t CryptoNative_SslGetClientHelloData(SSL* ssl, const uint8_t** data, int32_t* length)
+{
+    // No error queue impact.
+    if (data != NULL) *data = NULL;
+    if (length != NULL) *length = 0;
+
+    if (g_clientHelloExIndex < 0 || ssl == NULL)
+    {
+        return 0;
+    }
+
+    ClientHelloCapture* cap = (ClientHelloCapture*)SSL_get_ex_data(ssl, g_clientHelloExIndex);
+    if (cap == NULL || cap->data == NULL)
+    {
+        return 0;
+    }
+
+    if (data != NULL) *data = cap->data;
+    if (length != NULL) *length = cap->length;
+    return 1;
+}
+
 void CryptoNative_SslCtxSetKeylogCallback(SSL_CTX* ctx, SslCtxSetKeylogCallback cb)
 {
     // void shim functions don't lead to exceptions, so skip the unconditional error clearing.

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
@@ -167,6 +167,27 @@ It will unset callback if set is zero.
 PALEXPORT void CryptoNative_SslSetClientCertCallback(SSL* ssl, int set);
 
 /*
+Enables raw ClientHello inspection on the given context when enable is non-zero.
+
+When enabled, the server-side handshake pauses once at ClientHello time
+(SSL_do_handshake reports SSL_ERROR_WANT_CLIENT_HELLO_CB) and the raw ClientHello
+handshake message is captured so it can be retrieved via
+CryptoNative_SslGetClientHelloData. The handshake resumes on the next
+SSL_do_handshake call. No-op on OpenSSL versions without the ClientHello callback.
+*/
+PALEXPORT void CryptoNative_SslCtxSetClientHelloCallback(SSL_CTX* ctx, int32_t enable);
+
+/*
+Returns the captured raw ClientHello handshake message for the given SSL.
+
+On success returns 1 and writes the captured buffer pointer and length to the
+data and length out-parameters (owned by the SSL object, valid until SSL_free).
+Returns 0 if nothing was captured. The bytes are the TLS handshake message
+(HandshakeType + length prefix + body), without the outer 5-byte TLS record header.
+*/
+PALEXPORT int32_t CryptoNative_SslGetClientHelloData(SSL* ssl, const uint8_t** data, int32_t* length);
+
+/*
 Requests that client sends Post-Handshake Authentication extension in ClientHello.
 */
 PALEXPORT void CryptoNative_SslSetPostHandshakeAuth(SSL* ssl, int32_t val);


### PR DESCRIPTION
New API lets a server pause its handshake at the ClientHello and read the TLS client hello as was received by OpenSSL, before any certificate or server-option decision.

## 1. `TlsContext.EnableClientHelloInspection`

```diff
namespace System.Net.Security;

public sealed partial class TlsContext : IDisposable
{
+ public bool EnableClientHelloInspection { get; set; }
}
```

Opt-in flag, set on the server context before the first handshake. When `true`, the handshake suspends once at ClientHello. Default `false` (no behavior change).

## 2. `TlsOperationStatus.NeedsClientHello`

```diff
namespace System.Net.Security;

public enum TlsOperationStatus
{
        Complete = 0,
        WantRead = 1,
        WantWrite = 2,
        Closed = 3,
        WantCredentials = 4,
        NeedsCertificateValidation = 5,
        NeedsServerOptions = 6,

        /// <summary>
        /// Server-side only. The handshake paused at ClientHello because raw ClientHello
        /// inspection was enabled on the <see cref="TlsContext"/>. Retrieve the raw bytes
        /// via <see cref="TlsSession.GetClientHelloBytes"/>, then call
        /// <see cref="TlsSession.Handshake"/> (fd mode) or
        /// <see cref="TlsSession.ProcessHandshake"/> again to resume the handshake.
        /// </summary>
+        NeedsClientHello = 7,
}
```

New suspension reason returned by `Handshake()` / `ProcessHandshake()`. Means: the ClientHello has arrived and is available; call `GetClientHelloBytes()`, then call `Handshake()` / `ProcessHandshake()` again to resume.

## 3. `TlsSession.GetClientHelloBytes()`

```diff
namespace System.Net.Security;

public sealed partial class TlsSession
{
+ public ReadOnlySpan<byte> GetClientHelloBytes();
}
```

Returns the raw ClientHello handshake message (handshake type + 3-byte length + body; no 5-byte TLS record header). Zero-copy view over OpenSSL's own buffer; valid until the next `Handshake()` / `ProcessHandshake()` call. Empty if inspection wasn't enabled or the ClientHello hasn't arrived yet.

---

## Under the hood

When `EnableClientHelloInspection` is set, the server's `SSL_CTX` is armed with two OpenSSL callbacks: `SSL_CTX_set_msg_callback` (copies the inbound ClientHello bytes into per-`SSL` `ex_data`) and `SSL_CTX_set_client_hello_cb` (returns `SSL_CLIENT_HELLO_RETRY` **exactly once**). That makes `SSL_do_handshake` return `SSL_ERROR_WANT_CLIENT_HELLO_CB`, which the managed layer maps to `TlsOperationStatus.NeedsClientHello`. `GetClientHelloBytes()` just returns a span over the already-captured `ex_data` buffer — no parsing, no copy. The next `Handshake()` / `ProcessHandshake()` re-enters the suspended `SSL_do_handshake`, the callback now returns "success," and the handshake proceeds normally (emits ServerHello, etc.).

## How it maps to the two drive modes

- **fd-mode** (`Handshake()`, OpenSSL owns the socket): suspends after OpenSSL reads the ClientHello off the fd itself.
- **BIO-mode** (`ProcessHandshake(input, output, ...)`, caller owns the socket): the ClientHello is consumed from the `input` span into OpenSSL's BIO, then it suspends. On resume the caller passes **empty** input (the bytes were already consumed) and OpenSSL writes the ServerHello to the `output` span.

## Typical caller loop (fd-mode)

```csharp
using TlsContext ctx = TlsContext.Create(serverOptions);
ctx.EnableClientHelloInspection = true;                 // (1) opt in
using TlsSession server = TlsSession.Create(ctx, socketHandle);

while (true)
{
    TlsOperationStatus status = server.Handshake();
    switch (status)
    {
        case TlsOperationStatus.NeedsClientHello:        // (2) suspended once
            ReadOnlySpan<byte> hello = server.GetClientHelloBytes();
            InspectSniAlpn(hello);                       //     Kestrel parses it itself
            continue;                                    //     loop -> resumes
        case TlsOperationStatus.Complete:
            goto done;
        // ...WantRead / WantWrite / NeedsCertificateValidation...
    }
}
done: ;
```