### PR TITLE
TlsSession: fix BIO context type-confusion heap corruption in fd-mode socket path

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsSessionTests.cs
@@ -2883,5 +2883,119 @@ namespace System.Net.Security.Tests
 
             Assert.Throws<InvalidOperationException>(() => GetClientHelloBytesHelper(session));
         }
+
+        // Repro for the socket-replay/peek BIO heap corruption. A socket-bound (fd-mode)
+        // server session driven through the deferred-options path (NeedsTlsContext ->
+        // SetContext) activates the socket-replay write BIO. Calling Shutdown() on that
+        // session makes OpenSSL emit close_notify, which flows through the
+        // ManagedSpanBio-only window/spill helpers (BioSetWriteWindow / BioGetWriteResult /
+        // BioDrainSpill). On a socket-replay BIO those helpers must be no-ops; if they
+        // instead reinterpret the smaller SocketReplayBioCtx as a ManagedSpanBioCtx they
+        // write past the end of the allocation and silently corrupt the adjacent heap
+        // chunk. glibc then aborts on a later malloc/free ("free(): invalid next size" /
+        // "corrupted size vs. prev_size", SIGABRT), taking down the whole test host. That
+        // native abort is the only failure this test cares about; managed exceptions are
+        // swallowed. The deferred-options path engages the socket-replay BIO regardless of the
+        // CaptureClientHello switch, so no switch manipulation is needed here (and would
+        // otherwise pollute the parallel suite via the process-global AppContext switch).
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Linux)]
+        public async Task SocketBoundSession_DeferredOptions_ShutdownAcrossConnections_DoesNotCorruptHeap()
+        {
+            using X509Certificate2 serverCert = TestCertificates.GetServerCertificate();
+            string serverName = serverCert.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+
+            // One shared bootstrap context (empty options -> defers to NeedsTlsContext) and
+            // one real host context, mirroring Kestrel's DirectTls per-listener model.
+            using TlsContext bootstrapCtx = TlsContext.CreateServer(new SslServerAuthenticationOptions());
+            using TlsContext hostCtx = TlsContext.CreateServer(new SslServerAuthenticationOptions
+            {
+                ServerCertificate = serverCert,
+                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                ClientCertificateRequired = false,
+            });
+
+            // Each Shutdown() performs a fixed out-of-bounds write past a 24-byte calloc'd
+            // chunk; a handful of sequential connections is enough for glibc to trip on a
+            // subsequent allocation. Use a comfortable margin.
+            const int Connections = 32;
+            for (int i = 0; i < Connections; i++)
+            {
+                await RunOneDeferredShutdownConnectionAsync(bootstrapCtx, hostCtx, serverName);
+            }
+        }
+
+        private static async Task RunOneDeferredShutdownConnectionAsync(TlsContext bootstrapCtx, TlsContext hostCtx, string serverName)
+        {
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(1);
+            int port = ((IPEndPoint)listener.LocalEndPoint!).Port;
+
+            using Socket clientUnderlying = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            Task connect = clientUnderlying.ConnectAsync(IPAddress.Loopback, port);
+            Socket serverSocket = await listener.AcceptAsync();
+            await connect;
+
+            serverSocket.Blocking = false;
+            SafeSocketHandle serverHandle = serverSocket.SafeHandle;
+
+            using TlsSocketSession session = NewSocketSession(bootstrapCtx, serverHandle);
+
+            using SslStream clientSsl = new SslStream(new NetworkStream(clientUnderlying, ownsSocket: false), leaveInnerStreamOpen: false, TestHelper.AllowAnyServerCertificate);
+            Task clientHandshake = clientSsl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+            {
+                TargetHost = serverName,
+                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                RemoteCertificateValidationCallback = TestHelper.AllowAnyServerCertificate,
+            });
+
+            Task serverHandshake = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    TlsOperationStatus s = session.Handshake();
+                    if (s == TlsOperationStatus.Complete)
+                    {
+                        return;
+                    }
+                    if (s == TlsOperationStatus.NeedsTlsContext)
+                    {
+                        session.SetContext(hostCtx);
+                        continue;
+                    }
+                    if (s == TlsOperationStatus.NeedsCertificateValidation)
+                    {
+                        session.AcceptWithDefaultValidation();
+                        continue;
+                    }
+                    if (s == TlsOperationStatus.NeedMoreData || s == TlsOperationStatus.DestinationTooSmall)
+                    {
+                        await Task.Delay(5);
+                        continue;
+                    }
+                    throw new InvalidOperationException($"Unexpected handshake status: {s}");
+                }
+            });
+
+            await Task.WhenAll(clientHandshake, serverHandshake).WaitAsync(TimeSpan.FromSeconds(30));
+            Assert.True(session.IsHandshakeComplete);
+
+            // Drive close_notify from the server side -- the operation that flows through the
+            // window/spill helpers on the socket-replay write BIO.
+            TlsOperationStatus shutdownStatus = session.Shutdown();
+            GC.KeepAlive(shutdownStatus);
+
+            // Let the client observe EOF so the exchange is well-formed; the result is not
+            // asserted (the point of the test is the absence of a native abort).
+            try
+            {
+                byte[] buf = new byte[16];
+                await clientSsl.ReadAsync(buf).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch
+            {
+            }
+        }
     }
 }

--- a/src/native/libs/System.Security.Cryptography.Native/pal_bio.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_bio.c
@@ -127,8 +127,15 @@ int32_t CryptoNative_BioCtrlPending(BIO* bio)
  * operation so those bytes are not lost.
  */
 
+// First field of every custom BIO context is a magic tag identifying the concrete
+// type. The window/spill helpers below use it to reject BIOs that are not ManagedSpanBio
+// (see TryGetManagedSpanBioCtx) instead of type-confusing their context and corrupting the heap.
+#define DOTNET_BIO_TAG_MANAGED_SPAN  0x4D534249u // 'MSBI'
+#define DOTNET_BIO_TAG_SOCKET_REPLAY 0x53524250u // 'SRBP'
+
 typedef struct
 {
+    uint32_t       tag;
     const uint8_t* readPtr;
     int32_t        readLen;
     int32_t        readPos;
@@ -145,6 +152,29 @@ typedef struct
 static ManagedSpanBioCtx* GetManagedSpanBioCtx(BIO* bio)
 {
     return (ManagedSpanBioCtx*)BIO_get_data(bio);
+}
+
+// Sets *outCtx and returns non-zero only when 'bio' is one of our ManagedSpanBio instances.
+// The window/spill helpers interpret BIO_get_data() as a ManagedSpanBioCtx*; calling them on
+// any other BIO type (e.g. the SocketReplayBio used in the peek/deferred-server path, whose
+// context is smaller) would read and write past the end of that context, corrupting the heap.
+// The tag is the first field of every custom BIO context, so reading it is in-bounds for all
+// of them. Doing the single BIO_get_data() fetch, tag check, and NULL guard here means callers
+// touch the context only after it has been validated, and only load it once.
+static int TryGetManagedSpanBioCtx(BIO* bio, ManagedSpanBioCtx** outCtx)
+{
+    *outCtx = NULL;
+    if (bio == NULL)
+    {
+        return 0;
+    }
+    ManagedSpanBioCtx* ctx = (ManagedSpanBioCtx*)BIO_get_data(bio);
+    if (ctx == NULL || ctx->tag != DOTNET_BIO_TAG_MANAGED_SPAN)
+    {
+        return 0;
+    }
+    *outCtx = ctx;
+    return 1;
 }
 
 #define MANAGED_SPAN_SPILL_INITIAL 4096
@@ -298,6 +328,7 @@ static int ManagedSpanBioCreate(BIO* bio)
         return 0;
     }
 
+    ctx->tag = DOTNET_BIO_TAG_MANAGED_SPAN;
     BIO_set_data(bio, ctx);
     BIO_set_init(bio, 1);
     return 1;
@@ -369,13 +400,8 @@ BIO* CryptoNative_BioNewManagedSpan(void)
 
 void CryptoNative_BioSetReadWindow(BIO* bio, const void* ptr, int32_t len)
 {
-    if (bio == NULL)
-    {
-        return;
-    }
-
-    ManagedSpanBioCtx* ctx = GetManagedSpanBioCtx(bio);
-    if (ctx == NULL)
+    ManagedSpanBioCtx* ctx;
+    if (!TryGetManagedSpanBioCtx(bio, &ctx))
     {
         return;
     }
@@ -387,13 +413,13 @@ void CryptoNative_BioSetReadWindow(BIO* bio, const void* ptr, int32_t len)
 
 void CryptoNative_BioClearReadWindow(BIO* bio, int32_t* leftoverLength)
 {
-    if (bio == NULL)
+    if (leftoverLength != NULL)
     {
-        return;
+        *leftoverLength = 0;
     }
 
-    ManagedSpanBioCtx* ctx = GetManagedSpanBioCtx(bio);
-    if (ctx == NULL)
+    ManagedSpanBioCtx* ctx;
+    if (!TryGetManagedSpanBioCtx(bio, &ctx))
     {
         return;
     }
@@ -410,13 +436,8 @@ void CryptoNative_BioClearReadWindow(BIO* bio, int32_t* leftoverLength)
 
 void CryptoNative_BioSetWriteWindow(BIO* bio, void* ptr, int32_t capacity)
 {
-    if (bio == NULL)
-    {
-        return;
-    }
-
-    ManagedSpanBioCtx* ctx = GetManagedSpanBioCtx(bio);
-    if (ctx == NULL)
+    ManagedSpanBioCtx* ctx;
+    if (!TryGetManagedSpanBioCtx(bio, &ctx))
     {
         return;
     }
@@ -437,13 +458,8 @@ void CryptoNative_BioGetWriteResult(BIO* bio, int32_t* writtenToWindow, int32_t*
         *spillLen = 0;
     }
 
-    if (bio == NULL)
-    {
-        return;
-    }
-
-    ManagedSpanBioCtx* ctx = GetManagedSpanBioCtx(bio);
-    if (ctx == NULL)
+    ManagedSpanBioCtx* ctx;
+    if (!TryGetManagedSpanBioCtx(bio, &ctx))
     {
         return;
     }
@@ -460,13 +476,13 @@ void CryptoNative_BioGetWriteResult(BIO* bio, int32_t* writtenToWindow, int32_t*
 
 int32_t CryptoNative_BioDrainSpill(BIO* bio, void* dst, int32_t dstLen)
 {
-    if (bio == NULL || dst == NULL || dstLen <= 0)
+    ManagedSpanBioCtx* ctx;
+    if (dst == NULL || dstLen <= 0 || !TryGetManagedSpanBioCtx(bio, &ctx))
     {
         return 0;
     }
 
-    ManagedSpanBioCtx* ctx = GetManagedSpanBioCtx(bio);
-    if (ctx == NULL || ctx->spillLen == 0)
+    if (ctx->spillLen == 0)
     {
         return 0;
     }
@@ -506,6 +522,7 @@ int32_t CryptoNative_BioDrainSpill(BIO* bio, void* dst, int32_t dstLen)
 
 typedef struct
 {
+    uint32_t tag;
     uint8_t* prefix;
     int32_t  prefixLen;
     int32_t  prefixCap;
@@ -645,6 +662,7 @@ static int SocketReplayBioCreate(BIO* bio)
         return 0;
     }
 
+    ctx->tag = DOTNET_BIO_TAG_SOCKET_REPLAY;
     ctx->fd = -1;
 
     BIO_set_data(bio, ctx);


### PR DESCRIPTION
## Problem
The ManagedSpanBio window/spill helpers — `CryptoNative_BioSetReadWindow`, `BioClearReadWindow`, `BioSetWriteWindow`, `BioGetWriteResult`, `BioDrainSpill` — are called from `pal_ssl.c` on whichever BIO is attached to the `SSL*` (`SSL_get_rbio`/`SSL_get_wbio`) and unconditionally reinterpret `BIO_get_data()` as a `ManagedSpanBioCtx*`.

In the fd-bound `TlsSocketSession` path (deferred-options / SNI peek, or the ClientHello-capture path) the attached read/write BIO is a **SocketReplayBio**, whose context struct is smaller than `ManagedSpanBioCtx`. Casting it and writing the write-window fields runs **past the end of the `calloc`'d chunk**, and `BioDrainSpill` dereferences a garbage `spillBuf` pointer. This corrupts the adjacent heap chunk; glibc then aborts on a later allocation (`free(): invalid next size` / `corrupted size vs. prev_size`, `SIGABRT`) — e.g. on the second connection, or while `Shutdown()` drains `close_notify`.

## Fix
Add a `uint32_t` tag as the first field of **both** custom BIO context structs and validate it in a new `TryGetManagedSpanBioCtx` before any window/spill helper touches the context. The five helpers now no-op on any BIO that is not a ManagedSpanBio.

This is correct because socket BIOs move ciphertext through their own `bread`/`bwrite` callbacks (`recv`/`send` on the fd) and never participate in the managed-span window protocol — there is nothing to arm. The tag is the first field of every context, so reading it is in-bounds for any custom BIO. Behavior for genuine ManagedSpanBio instances is unchanged.

## Test
`SocketBoundSession_DeferredOptions_ShutdownAcrossConnections_DoesNotCorruptHeap`: drives sequential fd-mode deferred-SNI connections through handshake + `Shutdown()`. Core-dumps the test host on the **unfixed** native; **passes** with the fix.

## Validation
- Runtime: repro test 3/3 deterministic; rest of `TlsSessionTests` 44/44, no regressions (Debug, Linux/WSL).
- End-to-end: Kestrel DirectTls sample over this native served 40/40 sequential + 20/20 concurrent HTTPS 200 through the deferred-SNI peek path